### PR TITLE
Fix issue where invalid EXIF datetime could lead to invalid timestamp in database.

### DIFF
--- a/src/routers/photos.py
+++ b/src/routers/photos.py
@@ -155,7 +155,12 @@ async def finalize_upload(photo_id: str, photo_exif_secret: str, request_data: d
     photo.exif_update_secret = None
 
     if 'datetime_original' in exif_data.keys():
-        photo.timestamp = exif_data['datetime_original']
+        datetime_original = exif_data['datetime_original']
+        try:
+            parsed_datetime = datetime.datetime.strptime(datetime_original, '%Y:%m:%d %H:%M:%S')
+            photo.timestamp = datetime_original
+        except (ValueError, TypeError):
+            photo.timestamp = None
 
     gps_data = request_data['gps_data']
     if gps_data is not None:

--- a/src/routers/photos.py
+++ b/src/routers/photos.py
@@ -158,7 +158,7 @@ async def finalize_upload(photo_id: str, photo_exif_secret: str, request_data: d
         datetime_original = exif_data['datetime_original']
         try:
             parsed_datetime = datetime.datetime.strptime(datetime_original, '%Y:%m:%d %H:%M:%S')
-            photo.timestamp = datetime_original
+            photo.timestamp = parsed_datetime
         except (ValueError, TypeError):
             photo.timestamp = None
 


### PR DESCRIPTION
A photo with an invalid date in the EXIF data would have that set as the timestamp field in the database as well, making subsequent data validation mechanisms fail.

This change makes it so that an invalid EXIF timestamp results in a photo without a timestamp in the database, which is fine.

fixes #150 